### PR TITLE
Provide more detailed error information for load.

### DIFF
--- a/pngcanvas.py
+++ b/pngcanvas.py
@@ -220,9 +220,16 @@ class PNGCanvas(object):
         (width, height, bit_depth, color_type, compression,
          filter_type, interlace) = struct.unpack(b"!2I5B", header[1])
 
-        if (bit_depth, color_type, compression,
-                filter_type, interlace) != (8, 6, 0, 0, 0):
-            raise TypeError('Unsupported PNG format')
+        if bit_depth != 8:
+            raise ValueError('Unsupported PNG format (bit depth={}; must be 8)'.format(bit_depth))
+        if compression != 0:
+            raise ValueError('Unsupported PNG format (compression={}; must be 0)'.format(compression))
+        if filter_type != 0:
+            raise ValueError('Unsupported PNG format (filter_type={}; must be 0)'.format(filter_type))
+        if interlace != 0:
+            raise ValueError('Unsupported PNG format (interlace={}; must be 0)'.format(interlace))
+        if color_type != 6:
+            raise ValueError('Unsupported PNG format (color_type={}; must be 6)'.format(color_type))
 
         self.width = width
         self.height = height


### PR DESCRIPTION
When attempting to load a PNG file, if that file is unsupported
it is useful to provide the developer with a more precise
error message indicating the exact cause of the error.

Have also changed the type of exception to be a ValueError rather
than a TypeError. In this case the type is correct, however the
value recevied is incorrect (or at least unsupported).

Probably worth changing to a specific exception in the future.