### PR TITLE
Correctly handle loading data from multiple chunks

### DIFF
--- a/pngcanvas.py
+++ b/pngcanvas.py
@@ -317,8 +317,8 @@ class PNGCanvas(object):
                     value = c
                 cur[xc] = (cur[xc] + value) % 256
                 xp += 1
-            else:
-                raise TypeError('Unrecognized scanline filter type')
+        else:
+            raise ValueError('Unrecognized scanline filter type: {}'.format(filter_type))
         return cur
 
     @staticmethod


### PR DESCRIPTION
This change enables the load method to work correctly when
data exists in multiple IDAT chunks. A small ByteReader helper
class is created that takes in a chunk iterator, and provides
a simple 'read' method. The reader code can then simply
read a scanline at a time and add to the canvas.