### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ pngcanvas
 =========
 
 [![Build Status](https://travis-ci.org/rcarmo/pngcanvas.png?branch=master)](https://travis-ci.org/rcarmo/pngcanvas)
-[![PyPI Version](https://pypip.in/v/pngcanvas/badge.png)](https://pypi.python.org/pypi/pngcanvas/)
-[![Downloads](https://pypip.in/d/pngcanvas/badge.png)](https://pypi.python.org/pypi/pngcanvas/)
+[![PyPI Version](https://img.shields.io/pypi/v/pngcanvas.svg)](https://pypi.python.org/pypi/pngcanvas/)
+[![Downloads](https://img.shields.io/pypi/dm/pngcanvas.svg)](https://pypi.python.org/pypi/pngcanvas/)
 
 A minimalist library to render PNG images using pure Python inspired by [Thomas Fuchs'][madrobby] [spark_pr][spark_pr] library, originally published [here][tom] in 2005.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pngcanvas))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pngcanvas`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.